### PR TITLE
Fix database module syntax and API client typo

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,12 +1,12 @@
-import Database from 'better-sqlite3';
-import fs from 'fs';
-import path from 'path';
+const Database = require('better-sqlite3');
+const fs = require('fs');
+const path = require('path');
 
 const dbPath = process.env.DB_PATH || './data/scout.db';
 const dir = path.dirname(dbPath);
 if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 
-export const db = new Database(dbPath);
+const db = new Database(dbPath);
 
 // Schéma initial
 db.exec(`
@@ -87,8 +87,15 @@ CREATE TABLE IF NOT EXISTS children (
 
 // Migrations légères (ajouts de colonnes sans casser si déjà là)
 function safeAlter(sql) {
-  try { db.exec(sql); } catch { /* ignore si déjà appliqué */ }
+  try {
+    db.exec(sql);
+  } catch {
+    /* ignore si déjà appliqué */
+  }
 }
 
 // Ajoute colonne active sur users si absente
 safeAlter(`ALTER TABLE users ADD COLUMN active INTEGER NOT NULL DEFAULT 1;`);
+
+module.exports = db;
+

--- a/js/api.js
+++ b/js/api.js
@@ -102,9 +102,9 @@ const api = {
   async listCategories() {
     const res = await fetch(`${API_BASE}/finance/categories`, { headers: this.headers(false) });
     return res.json();
-  }
+  },
 
-  ,async listTransactions(params = {}) {
+  async listTransactions(params = {}) {
     const url = new URL(`${API_BASE}/finance/transactions`);
     Object.entries(params).forEach(([k, v]) => {
       if (v !== undefined && v !== null && v !== '') url.searchParams.set(k, v);


### PR DESCRIPTION
## Summary
- Convert database helper to CommonJS and export `db` instance
- Repair API client object syntax for `listTransactions`

## Testing
- `node --check js/api.js`
- `node --check backend/db.js`
- `npm test` *(fails: Missing script "test")*
- `npm start` *(fails: better-sqlite3 invalid ELF header)*

------
https://chatgpt.com/codex/tasks/task_e_6899101cf5848320bfb03e9c615b13d7